### PR TITLE
Allowing cyclicity in validation, fixing blueprint creation for cyclic topologies

### DIFF
--- a/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Capability.java
+++ b/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Capability.java
@@ -41,7 +41,10 @@ public class Capability implements Serializable{
 	public void setId(String id) {
 		this.id = id;
 	}
-	
-	
+
+	@Override
+	public String toString() {
+		return this.getClass().getName() + "[name="+getName()+",id="+getId()+"]";
+	}
 
 }

--- a/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Nodes.java
+++ b/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Nodes.java
@@ -208,4 +208,10 @@ public class Nodes implements Serializable {
 	public void setProtoUri(String protoUri) {
 		this.protoUri = protoUri;
 	}
+
+	@Override
+	public String toString() {
+		return this.getClass().getName() + "[name="+getName()+",nodeId="+getNodeId()+",nodeSolutionId="+getNodeSolutionId()+",requirements[]="+String.join(" ; ", java.util.Arrays.toString(getRequirements()))+",properties[]="+String.join(" ; ", java.util.Arrays.toString(getProperties()))+",capabilities[]="+String.join(" ; ", java.util.Arrays.toString(getCapabilities()))+",type="+getType().getName()+",protoUri="+getProtoUri()+"]";
+
+	}
 }

--- a/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Relations.java
+++ b/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Relations.java
@@ -119,9 +119,12 @@ public class Relations implements Serializable{
 	public void setRelationship(List<Relationship> relationship) {
 		this.relationship = relationship;
 	}
-	
-	
-	
-	
 
+	@Override
+	public String toString() {
+		return "Relations[linkName="+getLinkName()+",linkId="+getLinkId()+
+			",sourceNodeName="+getSourceNodeName()+",sourceNodeId="+getSourceNodeId()+",sourceNodeRequirement="+getSourceNodeRequirement()+
+			",targetNodeName="+getTargetNodeName()+",targetNodeId="+getTargetNodeId()+",targetNodeCapability="+getTargetNodeCapability()+
+			",relationship="+String.valueOf(getRelationship())+"]";
+	}
 }

--- a/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Requirements.java
+++ b/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Requirements.java
@@ -82,7 +82,9 @@ public class Requirements implements Serializable{
 		this.target_type = target_type;
 	}
 	
-	
-	
+	@Override
+	public String toString() {
+		return this.getClass().getName() + "[name="+getName()+",relationship="+getRelationship()+",target="+getTarget().toString()+", target_type="+getTarget_type()+", capability="+getCapability().toString()+"]";
+	}
 
 }

--- a/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Target.java
+++ b/ds-compositionengine/src/main/java/org/acumos/designstudio/ce/vo/cdump/Target.java
@@ -82,8 +82,10 @@ public class Target implements Serializable{
 	public void setId(String id) {
 		this.id = id;
 	}*/
-	
-	
-	
+
+	@Override
+	public String toString() {
+		return this.getClass().getName() + "[name="+getName()+",description="+getDescription()+"]";
+	}
 
 }


### PR DESCRIPTION
Validation now only checks for isolated nodes.

Cdump generation (different repository) is also faulty, so the check if a service that needs to provide an output also receives an input is commented out and a TODO is added.

The protobuf generator for pipelines without a data broker is removed, because it heavily depends on acyclicity assumptions that had to be removed ("first" and "last" nodes).

The blueprint generator mixed up connections between multiple services for nodes that have multiple incoming and outgoing connections. This is fixed.